### PR TITLE
Clase 3 - Decimales con precisión arbitraria

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,10 +1,14 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
 
 type MarketData struct {
 	Symbol            string
-	LastPrice         float64
+	LastPrice         decimal.Decimal
 	LastPriceDateTime time.Time
 }
 
@@ -15,7 +19,7 @@ type Wallet struct {
 
 type WalletItem struct {
 	Symbol   string
-	Quantity float64
+	Quantity decimal.Decimal
 }
 
 type GetWalletValueRequest struct {
@@ -24,6 +28,6 @@ type GetWalletValueRequest struct {
 
 type GetWalletValueResponse struct {
 	ID       string
-	Value    *float64
+	Value    decimal.NullDecimal
 	DateTime *time.Time
 }

--- a/pkg/service/wallet_test.go
+++ b/pkg/service/wallet_test.go
@@ -7,14 +7,15 @@ import (
 	"github.com/matbarofex/mtz-crypto/mocks"
 	"github.com/matbarofex/mtz-crypto/pkg/model"
 	"github.com/matbarofex/mtz-crypto/pkg/store/memory"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetWalletValue(t *testing.T) {
 	items := []model.WalletItem{
-		{Symbol: "SYM1", Quantity: 0.1},
-		{Symbol: "SYM2", Quantity: 0.1},
-		{Symbol: "SYM3", Quantity: 0.1},
+		{Symbol: "SYM1", Quantity: decimal.RequireFromString("0.1")},
+		{Symbol: "SYM2", Quantity: decimal.RequireFromString("0.1")},
+		{Symbol: "SYM3", Quantity: decimal.RequireFromString("0.1")},
 	}
 	wallet := model.Wallet{
 		ID:    "wallet1",
@@ -27,19 +28,19 @@ func TestGetWalletValue(t *testing.T) {
 	ts1, _ := time.Parse(time.RFC3339, "2021-09-23T12:34:56Z")
 	mdStore.SetOrUpdateMD(model.MarketData{
 		Symbol:            "SYM1",
-		LastPrice:         1.0,
+		LastPrice:         decimal.RequireFromString("1.0"),
 		LastPriceDateTime: ts1,
 	})
 	ts2, _ := time.Parse(time.RFC3339, "2021-09-23T13:34:56Z")
 	mdStore.SetOrUpdateMD(model.MarketData{
 		Symbol:            "SYM2",
-		LastPrice:         1.0,
+		LastPrice:         decimal.RequireFromString("1.0"),
 		LastPriceDateTime: ts2,
 	})
 	ts3, _ := time.Parse(time.RFC3339, "2021-09-23T14:34:56Z")
 	mdStore.SetOrUpdateMD(model.MarketData{
 		Symbol:            "SYM3",
-		LastPrice:         1.0,
+		LastPrice:         decimal.RequireFromString("1.0"),
 		LastPriceDateTime: ts3,
 	})
 
@@ -52,6 +53,6 @@ func TestGetWalletValue(t *testing.T) {
 	resp, err := walletService.GetWalletValue(req)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 0.3, *resp.Value)
+	assert.Equal(t, "0.3", resp.Value.Decimal.String())
 	assert.Equal(t, ts3, *resp.DateTime)
 }


### PR DESCRIPTION
Se reemplaza el uso de `float64` por decimales con precisión arbitraria.

Esto permite evitar errores por redondeo en los cálculos, por ejemplo para el cálculo del valor de la billetera.

Para ello vamos a utilizar en este proyecto la librería [decimal](https://github.com/shopspring/decimal)

Para agregar la dependencia, ejecutar

```
go get github.com/shopspring/decimal
```

Una vez modificados los tests y el código, el test que fallaba pasa OK