### PR TITLE
Clase 5 - Wallet cache

### DIFF
--- a/cmd/mtz-crypto-service/flags.go
+++ b/cmd/mtz-crypto-service/flags.go
@@ -31,6 +31,13 @@ var (
 	_ = fs.Int("crypto.api.cryptonator.workers", 2, "Número de workers para pedidos concurrentes a la API externa")
 )
 
+// Cache
+var (
+	_ = fs.Bool("crypto.cache.enabled", true, "Habilitar cache en memoria")
+	_ = fs.Duration("crypto.cache.default.expiration", 5*time.Minute, "Tiempo de vida por defecto de keys en cache")
+	_ = fs.Duration("crypto.cache.cleanup.interval", 10*time.Minute, "Intervalo de limpieza de keys expiradas")
+)
+
 // Postgres
 var (
 	_ = fs.String("crypto.postgres.host", "localhost", "Host de la base de Postgres")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/gin-contrib/zap v0.0.1
 	github.com/gin-gonic/gin v1.7.4
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/shopspring/decimal v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/store/cache/wallet.go
+++ b/pkg/store/cache/wallet.go
@@ -1,0 +1,33 @@
+package cache
+
+import (
+	"github.com/matbarofex/mtz-crypto/pkg/model"
+	"github.com/matbarofex/mtz-crypto/pkg/store"
+	"github.com/patrickmn/go-cache"
+)
+
+type walletCacheStore struct {
+	cache       *cache.Cache
+	walletStore store.WalletStore
+}
+
+func NewWalletCacheStore(cache *cache.Cache, walletStore store.WalletStore) store.WalletStore {
+	return &walletCacheStore{
+		cache:       cache,
+		walletStore: walletStore,
+	}
+}
+
+func (s *walletCacheStore) GetWallet(walletID string) (rs model.Wallet, err error) {
+	wallet, found := s.cache.Get(walletID)
+	if !found {
+		wallet, err = s.walletStore.GetWallet(walletID)
+		if err != nil {
+			return rs, err
+		}
+
+		s.cache.Set(walletID, wallet, 0)
+	}
+
+	return wallet.(model.Wallet), nil
+}


### PR DESCRIPTION
Para evitar el acceso a la DB en cada request, se agrega una cache en memoria usando la librería [`go-cache`](https://github.com/patrickmn/go-cache).

Ejemplo de uso simple de go-cache, obtenido de la página de la librería:

```go
import (
	"fmt"
	"github.com/patrickmn/go-cache"
	"time"
)

func main() {
	// Create a cache with a default expiration time of 5 minutes, and which
	// purges expired items every 10 minutes
	c := cache.New(5*time.Minute, 10*time.Minute)

	// Set the value of the key "foo" to "bar", with the default expiration time
	c.Set("foo", "bar", cache.DefaultExpiration)

	// Get the string associated with the key "foo" from the cache
	foo, found := c.Get("foo")
	if found {
		fmt.Println(foo)
	}
}
```

https://play.golang.org/p/mZPJBvqALZm

En este PR creamos una implementación de la interface `store.WalletStore` que utiliza la cache `go-cache`: en caso de no encontrar el elemento buscado utiliza el store original que interactúa con PostgreSQL y lo almacena en cache.

Con el flag `--crypto.cache.enabled` (o la env var `MTZ_CRYPTO_CACHE_ENABLED`) podemos activar/desactivar esta funcionalidad.
