### PR TITLE
Clase 5 - Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+ARG GO_VERSION=1.17
+
+# STAGE 1: build - creación del archivo ejecutable
+FROM golang:${GO_VERSION}-alpine AS build
+
+RUN apk add --no-cache git
+
+WORKDIR /work
+ADD cmd ./cmd
+ADD pkg ./pkg
+ADD go.mod ./go.mod
+ADD go.sum ./go.sum
+
+RUN CGO_ENABLED=0 go build -o /service ./cmd/mtz-crypto-service
+
+# STAGE 2: imagen de salida, con el servicio ejecutable
+FROM gcr.io/distroless/static AS final
+
+ARG SVC_NAME
+ARG APP_VSN
+ARG GIT_COMMIT
+ARG BUILD_DATE
+
+USER nonroot:nonroot
+ 
+COPY --from=build --chown=nonroot:nonroot /service /service
+
+ENV MTZ_CRYPTO_LOGGING_FORMAT="json" \
+    VERSION=${APP_VSN}
+
+EXPOSE 8000/tcp
+
+ENTRYPOINT ["/service"]
+
+# ----------------------------------------------------------------------------------------
+# IMPORTANTE: Mantener estas líneas al FINAL del archivo
+# ----------------------------------------------------------------------------------------
+LABEL org.opencontainers.image.url="https://github.com/matbarofex/mtz-crypto" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="Matriz SA" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.ref.name="mtzio/mtz-crypto" \
+      org.opencontainers.image.title="mtz-crypto" \
+      org.opencontainers.image.description="Servicio de ejemplo para capacitación Go" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+# ----------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+SVC_NAME := $(shell grep 'const ServiceName' pkg/version.go | cut -f2 -d '"')
+APP_VSN := $(shell grep 'const Version' pkg/version.go | cut -f2 -d '"')
+GIT_COMMIT := $(shell git rev-parse HEAD)
+BUILD_DATE := $(shell date --iso-8601=seconds)
+IMAGE_NAME := mtzio/${SVC_NAME}
+
 .PHONY: build
 build:
 	go build -o mtz-crypto-service ./cmd/...
@@ -22,3 +28,19 @@ lint:
 .PHONY: load-test
 load-test:
 	h2load --h1 -c 50 -t 4 -D 10 --warm-up-time=2s -i test-urls.txt -B 'http://localhost:8000'
+
+.PHONY: docker-build
+docker-build:
+	docker build \
+		--build-arg SVC_NAME="$(SVC_NAME)" \
+		--build-arg APP_VSN="$(APP_VSN)" \
+		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg BUILD_DATE="$(BUILD_DATE)" \
+		-t $(IMAGE_NAME):$(APP_VSN)-$(GIT_COMMIT) \
+		-t $(IMAGE_NAME):latest \
+		.
+
+.PHONY: docker-push
+docker-push:
+	docker push $(IMAGE_NAME):$(APP_VSN)-$(GIT_COMMIT)
+	docker push $(IMAGE_NAME):latest


### PR DESCRIPTION
[Docker](https://docs.docker.com/get-started/) es una tecnología de gestión de contenedores de amplio uso hoy en día, tanto en entornos productivos como también en ambientes de desarrollo.

Los contenedores son creados a partir de **imágenes docker**.

El Dockerfile es una "receta" o script de instrucciones para generar una imagen docker. Esas instrucciones van generando capas (layers). Una imagen puede servir de base para generar otra imagen.

El proceso de `build` consiste en generar una imagen docker a partir de un Dockerfile. Luego esa imagen se puede ejecutar (`run`) todas las veces que sea necesario, creando uno o más containers.

![](https://geekflare.com/wp-content/uploads/2019/07/dockerfile.png)

Para compartir imágenes Docker, es necesario usar un **Docker Registry**. El registry por default es [Docker Hub](https://hub.docker.com/), aunque es usual trabajar con registries privadas. Dentro de un registry, las imágenes se organizan en **repositories**. El nombre de la imagen docker incluye registry (si se usa alguno diferente al default registry), repository y tag.

Ejemplo:

```
mtzio/mtz-crypto:0.1.0-602f07f577382ec3d199ddbccefeb552cc009c8b

- docker registry: no se especifica, por lo tanto es Docker Hub
- repo: mtzio/mtz-crypto
- tag: 0.1.0-602f07f577382ec3d199ddbccefeb552cc009c8b
```

Otro ejemplo:

```
myprivateregistry:5000/group/project:1.2.3

- docker registry: myprivateregistry:5000
- repo: group/project
- tag: 1.2.3
```

------

En este PR se define un Dockerfile para creación de la imagen desplegable del servicio `mtz-crypto`.

Se utiliza un Dockerfile en 2 fases (multi stage build).

Esto permite especificar una imagen base para el proceso de **compilación** o build, distinta a la imagen base necesaria para la **ejecución** del servicio.

Se incorpora un target de Makefile `docker-build` para producir la imagen docker y `docker-push` para pushear la imagen al repositorio. Importante: docker push requiere credenciales para push en el repositorio en cuestión.

Pasos para ejecutar la imagen docker utilizando el archivo `docker-compose.yml`:

1. Crear la imagen docker, con `make docker-build`
2. Modificar (por única vez) el archivo `docker-compose.yml` agregando:

```diff
version: "3.8"
services:
  db:
    image: postgres:13-alpine
    volumes:
      - ./scripts/postgres-dev:/docker-entrypoint-initdb.d:ro
    ports:
      - 5432:5432
    environment:
      POSTGRES_DB: crypto_db_dev
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: postgres

+  mtz-crypto:
+    image: mtzio/mtz-crypto
+    ports:
+      - 8000:8000
+    environment:
+      MTZ_CRYPTO_POSTGRES_HOST: db
```

3. Levantar el entorno con `docker-compose up`
4. Probar, accediendo a `http://localhost:8000/wallet/value?wallet=wallet1`

### Dockerfile

Referencia de la sintaxis: https://docs.docker.com/engine/reference/builder/

#### Labels

Los labels permiten establecer metadata acerca de la imagen docker. En este PR se incluyen labels siguiendo lineamientos de [OCI (Open Container Initiative)](https://opencontainers.org/). Más información en https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys.

```dockerfile
LABEL org.opencontainers.image.url="https://github.com/matbarofex/mtz-crypto" \
      org.opencontainers.image.version="${VERSION}" \
      org.opencontainers.image.vendor="Matriz SA" \
      org.opencontainers.image.licenses="MIT" \
      org.opencontainers.image.ref.name="mtzio/mtz-crypto" \
      org.opencontainers.image.title="mtz-crypto" \
      org.opencontainers.image.description="Servicio de ejemplo para capacitación Go" \
      org.opencontainers.image.revision="${GIT_COMMIT}" \
      org.opencontainers.image.created="${BUILD_DATE}"
```
