### PR TITLE
Mejoras en target test de Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ generate-mocks:
 
 .PHONY: test
 test: build
-	go test -covermode=atomic -race -v -count=1 -coverprofile=coverage.out ./pkg/...
+	go test -v -race -count=1 -coverprofile=coverage.out ./pkg/...
 	go tool cover -func coverage.out | grep total
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ generate-mocks:
 .PHONY: test
 test: build
 	go test -v -race -coverprofile=coverage.out ./pkg/...
-	go tool cover -func coverage.out | grep total
+	go tool cover -func=coverage.out
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ generate-mocks:
 
 .PHONY: test
 test: build
-	go test -v -race -count=1 -coverprofile=coverage.out ./pkg/...
+	go test -v -race -coverprofile=coverage.out ./pkg/...
 	go tool cover -func coverage.out | grep total
 
 .PHONY: lint


### PR DESCRIPTION
- Se retira flag `covermode` que adopta ese default value con el flag `-race` activado
- Se retira flag `count` que mantenía su default value
- Se muestra la salida completa del reporte de cobertura en lugar del total únicamente